### PR TITLE
Add legacy code for wrong video location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ dmypy.json
 
 # Example dataset
 181129/
+/.project

--- a/PythonAPI/bam.py
+++ b/PythonAPI/bam.py
@@ -77,6 +77,13 @@ class BAM:
         :param video: if None all videos are unrolled.
                       If it has a concrete value, only that video is unrolled
         """
+        # LEGACY move videos from paper-location to code-location
+        for c in range(self.num_cameras):
+            paper_location = os.path.join(self.videos_dir, "camera"+str(c).zfill(2),"recording.mp4")
+            if os.path.isfile(paper_location):
+                code_location = os.path.join(self.dataset_dir, self.dataset_name + '_' + str(c).zfill(2) + '.mp4')
+                os.rename(paper_location, code_location)
+
         # Remove folders
         if force:
             if video is None:   # remove videos folder


### PR DESCRIPTION
In the paper a different folder structure is mentioned than actually in the dataset. When using the paper's folder structure the code crashes. This change checks for the paper-locations and moves the videos accordingly.